### PR TITLE
Fixing typos (and a footnote) for Chapter_01

### DIFF
--- a/src/03_Chapter_01_A_day_in_the_life_of_a_clean_system.adoc
+++ b/src/03_Chapter_01_A_day_in_the_life_of_a_clean_system.adoc
@@ -11,7 +11,7 @@ In this chapter I will introduce the reader to a (very simple) system designed w
 
 In the rest of the book, we will design together part of a simple web application that provides a room renting system. So, let's consider that our "Rent-o-Matic" applicationfootnote:[Fans of "Day of the Tentacle" should get the reference.] is running at https://www.rentomatic.com, and that a user wants to see the available rooms. They open the browser and type the address, then clicking on menus and buttons they reach the page with the list of all the rooms that our company rents.
 
-Let's assume that this URL is `/rooms?status=available`. When the user's browser accesses that URL, an HTTP request reaches our system, where there is a component that is waiting for HTTP connections. Let's call this component "web framework"footnote:[There are many more layers that the HTTP request has to go through before reaching the actual web framework, for example the web server, but since the purpose of those layers is mostly to increase performances, I am not going to consider them until the end of the book.]
+Let's assume that this URL is `/rooms?status=available`. When the user's browser accesses that URL, an HTTP request reaches our system, where there is a component that is waiting for HTTP connections. Let's call this component "web framework"footnote:[There are many more layers that the HTTP request has to go through before reaching the actual web framework, for example the web server, but since the purpose of those layers is mostly to increase performances, I am not going to consider them until the end of the book.].
 
 The purpose of the web framework is to understand the HTTP request and to retrieve the data that we need to provide a response. In this simple case there are two important parts of the request, namely the endpoint itself (`/rooms`), and a single query string parameter, `status=available`. Endpoints are like commands for our system, so when a user accesses one of them, they signal to the system that a specific service has been requested, which in this case is the list of all the rooms that are available for rent.
 
@@ -75,7 +75,7 @@ A relational database is hundred of times richer and more complex than an HTTP e
 
 How can we avoid strong coupling? A simple solution is called _inversion of control_, and I will briefly sketch it here, and show a proper implementation in a later section of the book, when we will implement this very example.
 
-Inversion of control happens in two phases. First, the called object (the database in this case) is wrapped with a standard interface. This is a set of functionalities shared by every implementation of the target, and each interface translates the functionalities to calls to the specific language[^language] of the wrapped implementation.
+Inversion of control happens in two phases. First, the called object (the database in this case) is wrapped with a standard interface. This is a set of functionalities shared by every implementation of the target, and each interface translates the functionalities to calls to the specific languagefootnote:[The word _language_, here, is meant in its broader sense. It might be a programming language, but also an API, a data format, or a protocol.] of the wrapped implementation.
 
 [TIP]
 ====
@@ -84,8 +84,6 @@ A technique used to avoid strong coupling between components of a system, that i
 ====
 
 A real world example of this is that of power plugs: electric appliances are designed to be connected not with specific power plugs, but to any power plug that is build according to the specification (size, number of poles, etc). When you buy a TV in the UK, you expect it to come with a UK plug (BS 1363). If it doesn't, you need an _adapter_ that allows you to plug electronic devices into sockets of a foreign nation. In this case, we need to connect the use case (TV) to a database (power system) that have not been designed to match a common interface.
-
-[^language]: The word _language_, here, is meant in its broader sense. It might be a programming language, but also an API, a data format, or a protocol.
 
 In the example we are discussing, the use case needs to extract all rooms with a given status, so the database wrapper needs to provide a single entry point that we might call `list_rooms_with_status`.
 
@@ -131,7 +129,7 @@ image::images/figure09.svg[The web framework replaced by a CLI]
 .A database replaced by a more trivial file-based storage
 image::images/figure10.svg[A database replaced by a more trivial file-based storage]
 
-As you can see, both changes would require the replacement of some components. Aafter all, we need different code to manage a command line instead of a web page. But the external shape of the system doesn't change, neither does the way data flows. We created a system in which the user interface (web framework, command-line interface) and the data source (relational database, text files) are details of the implementation, and not core parts of it.
+As you can see, both changes would require the replacement of some components. After all, we need different code to manage a command line instead of a web page. But the external shape of the system doesn't change, neither does the way data flows. We created a system in which the user interface (web framework, command-line interface) and the data source (relational database, text files) are details of the implementation, and not core parts of it.
 
 The main immediate advantage of a layered architecture, however, is testability. When you clearly separate components you clearly establish the data each of them has to receive and produce, so you can ideally disconnect a single component and test it in isolation. Let's take the Web framework component that we added and consider it for a moment forgetting the rest of the architecture. We can ideally connect a tester to its inputs and outputs as you can see in the figure
 


### PR DESCRIPTION
Typos:
1.  missing '.' after "web framework" footnote (sect. 1.1);
2. Fixing footnote about 'language' from markua-style to the current ones (guessing the syntax based on the other footnotes - I hope that's right).
3. Aafter -> after

(Issues with "cut" images already documented in the issue section)