### PR TITLE
Remove-explanation-line-number

### DIFF
--- a/src/02_About_the_book.mau
+++ b/src/02_About_the_book.mau
@@ -41,7 +41,7 @@ def example():
     print("This is a code block")
 ----
 
-Note that the path of the file that contains the code is printed just before the source code. Code blocks don't include line numbers, as the part of code that are being discussed are usually repeated in the text. This also makes it possible to copy the code from the PDF directly.
+Note that the path of the file that contains the code is printed just before the source code.
 
 Shell commands are presented with a generic prompt `$`
 


### PR DESCRIPTION
Hello !

First of all thanks for publishing this book, I started to read it recently and it looks very interesting :slightly_smiling_face: 

I noticed there's still a comment about missing line number for code block while it seems it was added in the second version:


![Screenshot from 2022-01-18 08-26-19](https://user-images.githubusercontent.com/39669025/149890882-1a330159-7c0c-4b27-bab9-595225b259d6.png)

(In the MR, I edited the .mau file to but didn't try to re-generate the pdf with the changes as they seem quite simple)

Thanks !
