### PR TITLE
Fix-less-more-than-sign

### DIFF
--- a/src/07_Chapter_05_Error_management.mau
+++ b/src/07_Chapter_05_Error_management.mau
@@ -193,7 +193,7 @@ Now we have a standard way to pack input and output values, and the above patter
 
 == Request validation
 
-The parameter `filters` that we want to add to the use case allows the caller to add conditions to narrow the results of the model list operation, using a notation like `&lt;attribute&gt;__&lt;operator&gt;`. For example, specifying `filters={'price__lt': 100}` should return all the results with a price lower than 100. 
+The parameter `filters` that we want to add to the use case allows the caller to add conditions to narrow the results of the model list operation, using a notation like `<attribute>__<operator>`. For example, specifying `filters={'price__lt': 100}` should return all the results with a price lower than 100.
 
 Since the model `Room` has many attributes, the number of possible filters is very high. For simplicity's sake, I will consider the following cases:
 


### PR DESCRIPTION
Hello :wave: 

I noticed the `<` and `>` char were displayed as `&lt;` and `&gt;` in the "Request validation" section, probably because it is enclosed by some backtick !
(I wasn't able to test it correctly fix but It looks like it's done like that in other  part of the book)

Thanks again for writing this book !